### PR TITLE
Fixed client crash when connecting to games with a password.

### DIFF
--- a/TTYDClient.py
+++ b/TTYDClient.py
@@ -246,7 +246,6 @@ async def ttyd_sync_task(ctx: TTYDContext):
                             dolphin.un_hook()
                             await asyncio.sleep(3)
                             continue
-                    await ctx.server_auth()
                     await asyncio.sleep(0.1)
                 except Exception as e:
                     dolphin.un_hook()


### PR DESCRIPTION
[Bug Report from Discord](https://discord.com/channels/1336598711241019453/1363010598908072067)

Will say upfront I'm not knowledgeable about Archipelago's libraries so this may need additional testing, but when I compared the code to a few other clients, they seem to not call `ctx.server_auth()`, seemingly like it runs on its own. So I removed the call from the loop, and I was able to connect to a passworded game without issue. Also tested it by entering an incorrect password, then the correct password, and it works as expected.