### PR TITLE
Breaking out docstring to better explain game in places where this docstring is referenced

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -68,7 +68,10 @@ class TTYDSettings(Group):
 
 class TTYDWorld(World):
     """
-    TTYD
+    Paper Mario: The Thousand-Year Door is a quirky, turn-based RPG with a paper-craft twist.
+    Mario teams up with oddball allies to stop an ancient evil sealed behind a magical door.
+    Set in Rogueport, the game mixes platforming, puzzles, and witty, self-aware dialogue.
+    Battles play out on a stage with timed button presses and a live audience cheering you on.
     """
     game = "Paper Mario: The Thousand-Year Door"
     web = TTYDWebWorld()


### PR DESCRIPTION
With APWorlds like APWorld Manager found [here](https://github.com/silasary/Archipelago/releases?q=Manager) now being able to display a description from the World class's docstring, expanding off of what is currently in the world to better explain the game itself.