### PR TITLE
fix: avoid passing set-ordered locations into the fill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -497,16 +497,20 @@ class TTYDWorld(World):
                      locations.keys() if chapters != chapter for item in self.limited_items[chapters][tag]}
                 if len(self.limited_items[chapter][tag]) == 0:
                     continue
+                fill_locations = sorted(locs, key=lambda loc: loc.name)
+                self.random.shuffle(fill_locations)
                 fill_restrictive(
                     self.multiworld,
                     state,
-                    list(locs),
+                    fill_locations,
                     self.limited_items[chapter][tag],
                     single_player_placement=True,
                     lock=True
                 )
         self.in_pre_fill = False
-        fast_fill(self.multiworld, self.limited_misc_items, list(self.limited_misc_locations))
+        misc_locations = sorted(self.limited_misc_locations, key=lambda loc: loc.name)
+        self.random.shuffle(misc_locations)
+        fast_fill(self.multiworld, self.limited_misc_items, misc_locations)
 
     def fill_hook(self, progitempool: List[Item], usefulitempool: List[Item],
                   filleritempool: List[Item], fill_locations: List[Location]) -> None:


### PR DESCRIPTION
Both `locs` and `self.limited_misc_locations` evaluate as `set`s, which have a non-deterministic order.  As a result, with a same generation seed, locations can appear in a different order on repeated generations.

This was found via the determinism hook of Eijebong's fuzzer.  The hook runs generation twice in the same process, so the set order difference is more likely to occur in that context as opposed to repeated generation runs 

I'm assuming you wanted an actual random order here, but I'm not 100% confident.
